### PR TITLE
Added gitpod.yaml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -23,7 +23,7 @@ tasks:
      echo "}" >> .tflint.hcl
      tflint --init
   - init: > 
-            URL=$(curl -v https://api.github.com/repos/trilogy-group/cloudfix-linter/releases>&1 
+            URL=$(curl -v https://api.github.com/repos/trilogy-group/cloudfix-linter/releases/latest>&1 
             | grep -v ant | grep browser_download_url | grep -v .asc | cut -d '"' -f 4) && wget $URL 
             && ZIP="$(find . -maxdepth 1 -name "namebefore-*-release.zip")" && unzip -qq $ZIP
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/


### PR DESCRIPTION
The sequence in which gitpod sets up the environment:-
1). Setup terraform.
2). Setup jq. ( will remove this when we update and remove jq from our orchestrator).
3). Setting up AWS credentials (exporting it as env variables), will show dummy credentials on a bash terminal so that user can just copy those commands and add their credentials to export commands .
4). Installing tflint.
5). Adding the ".tflint.hcl" file and adding the required content to it.
6). Fetching orchestrator release binary from main "Cloudfix-linter" repo release page. 

What needs to be done by the user:- 

- Running the terraform commands ( Terraform init, apply and some extra commands given in the readme.)
- Updating reccos.json with resource ids from the output of terraform commands ( See 6th point in the readme).
- Running "./orchestrator" 